### PR TITLE
Add ask form for language prompt

### DIFF
--- a/Dashboard/index.py
+++ b/Dashboard/index.py
@@ -1,6 +1,9 @@
 import streamlit as st
 import importlib
 
+if "page" not in st.session_state:
+    st.session_state.page = "dashboard"
+
 # Set page config
 st.set_page_config(
     page_title="Dashboard FinAppretinceship",
@@ -76,3 +79,13 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+if st.button("👉 Stell deine Frage"):
+    st.session_state.page = "question"
+
+import lan_prompt
+
+if st.session_state.page == "dashboard":
+    pass
+elif st.session_state.page == "question":
+    lan_prompt.show()

--- a/Dashboard/lan_prompt.py
+++ b/Dashboard/lan_prompt.py
@@ -1,0 +1,16 @@
+# lan_prompt.py
+
+import streamlit as st
+
+def show():
+    st.header("❓ Ask your question about Apprenticeship")
+    st.write("We are here to help. Please describe your question in detail.")
+
+    question = st.text_area("📝 Type your question here:")
+
+    if st.button("Submit"):
+        if question.strip():
+            st.success("🧠 Analyzing...")
+            # here will be implemented redirect to needed page based on result from LLM model
+        else:
+            st.error("⚠️ Please enter a question before submitting.")


### PR DESCRIPTION
Idea: Implement a question input form where the user can ask a free-text question related to the Apprenticeship.
The question is analyzed by a language model (LLM), and based on the detected intent or topic, the app displays a relevant chart from the already implemented dashboard (e.g. filtered by profession, region.

This sets the foundation for natural language interaction with the dashboard and intelligent navigation through visual data.

